### PR TITLE
Removing useless verification

### DIFF
--- a/assets/js/terrabrasilis-oauth-api.js
+++ b/assets/js/terrabrasilis-oauth-api.js
@@ -775,7 +775,7 @@ var AuthenticationService = {
   },
   isAuthenticated()
   {
-    return  Authentication.hasToken() && !Authentication.expirationCheck();
+    return  Authentication.hasToken();
   },
   getBearer()
   { 


### PR DESCRIPTION
Remove  && !Authentication.expirationCheck() from isAuthenticated() return